### PR TITLE
Updated registration logic so that if a class only has an abstract cl…

### DIFF
--- a/samples/Saucy.Console/AbstractRegistration/SomethingUsingTheAbstractBaseClassAndTheInterface.cs
+++ b/samples/Saucy.Console/AbstractRegistration/SomethingUsingTheAbstractBaseClassAndTheInterface.cs
@@ -1,7 +1,6 @@
 namespace Saucy.Console.AbstractRegistration;
 
 [SaucyInclude(ServiceScope.Transient)]
-[SaucyOnlyRegisterInterface]
 public class SomethingUsingTheAbstractBaseClassAndTheInterface : AbstractRegistrationBaseClass, ISomeInterface
 {
 

--- a/src/SaucyRegistrations.Generators/SaucyGenerator.cs
+++ b/src/SaucyRegistrations.Generators/SaucyGenerator.cs
@@ -61,7 +61,7 @@ public sealed class SaucyGenerator : IIncrementalGenerator
         );
 
         ctx.AddSource(
-            "Saucy.Attributes.SaucyOnlyRegisterInterface.g.cs", SourceText.From(SaucyOnlyRegisterInterface.SaucyOnlyRegisterInterfaceAttributeDefinition, Encoding.UTF8)
+            "Saucy.Attributes.SaucyOnlyRegisterInterface.g.cs", SourceText.From(SaucyRegisterAbstractClass.SaucyRegisterAbstractClassAttributeDefinition, Encoding.UTF8)
         );
     }
 
@@ -181,7 +181,7 @@ public sealed class SaucyGenerator : IIncrementalGenerator
         }
         else
         {
-            foreach (ServiceDefinition serviceDefinition in servicesToRegister)
+            foreach (ServiceDefinition serviceDefinition in servicesToRegister.OrderBy(x => x.FullyQualifiedClassName))
             {
                 var serviceScopeValue = (int)serviceDefinition.ServiceScope!;
                 var serviceScope = serviceScopeEnumValues[serviceScopeValue];

--- a/src/SaucyRegistrations.Generators/SaucyRegistrations.Generators.csproj
+++ b/src/SaucyRegistrations.Generators/SaucyRegistrations.Generators.csproj
@@ -13,7 +13,7 @@
         <License>https://github.com/aspeckt-112/SaucyRegistrations/blob/main/LICENSE</License>
         <RepositoryUrl>https://github.com/aspeckt-112/SaucyRegistrations</RepositoryUrl>
         <RepositoryType>Git</RepositoryType>
-        <Version>0.0.3-beta</Version>
+        <Version>0.0.5-beta</Version>
         <PackageId>SaucyRegistrations</PackageId>
         <Authors>aspeckt112</Authors>
     </PropertyGroup>

--- a/src/SaucyRegistrations.Generators/SourceConstants/Attributes/SaucyRegisterAbstractClass.cs
+++ b/src/SaucyRegistrations.Generators/SourceConstants/Attributes/SaucyRegisterAbstractClass.cs
@@ -1,18 +1,18 @@
 namespace SaucyRegistrations.Generators.SourceConstants.Attributes;
 
 /// <summary>
-/// The definition of the SaucyOnlyRegisterInterface attribute.
+/// The definition of the SaucyRegisterAbstractClass attribute.
 /// </summary>
-internal static class SaucyOnlyRegisterInterface
+internal static class SaucyRegisterAbstractClass
 {
     /// <summary>
-    /// The value of the SaucyOnlyRegisterInterface attribute.
+    /// The value of the SaucyRegisterAbstractClass attribute.
     /// </summary>
-    internal const string SaucyOnlyRegisterInterfaceAttributeDefinition = $$"""
+    internal const string SaucyRegisterAbstractClassAttributeDefinition = $$"""
                                                                             [System.AttributeUsage(System.AttributeTargets.Class, Inherited = false, AllowMultiple = false)]
-                                                                            internal class {{nameof(SaucyOnlyRegisterInterface)}} : System.Attribute
+                                                                            internal class {{nameof(SaucyRegisterAbstractClass)}} : System.Attribute
                                                                             {
-                                                                                internal {{nameof(SaucyOnlyRegisterInterface)}}() { }
+                                                                                internal {{nameof(SaucyRegisterAbstractClass)}}() { }
                                                                             }
                                                                             """;
 }


### PR DESCRIPTION
…ass, it's registered with that. If it's got an abstract class and any interfaces, it's only registered with the interfaces - unless the user explicitly registers with an abstract class.